### PR TITLE
adding target and rule for heat_data_reg

### DIFF
--- a/Solutions/makefile
+++ b/Solutions/makefile
@@ -66,6 +66,10 @@ heat_map_target$(EXE): heat_map_target.$(OBJ)
 heat_target_opt$(EXE): heat_target_opt.$(OBJ)
 	$(CLINKER) $(OPTFLAGS) -o heat_target_opt$(EXE) heat_target_opt.$(OBJ) $(LIBS)
 
+heat_data_reg$(EXE): heat_data_reg.$(OBJ)
+	$(CLINKER) $(OPTFLAGS) -o heat_data_reg$(EXE) heat_data_reg.$(OBJ) $(LIBS)
+
+
 test: $(EXES)
 	for i in $(EXES); do \
             $(PRE)$$i; \


### PR DESCRIPTION
Hi all,

There was a target missing from the `makefile` in the `Solutions` directory. Make was creating an implicit rule for the creation of the `heat_data_reg` executable and it wasn't linking the `LIBS` variable. I also had to add the math library `-lm` to `make.def` in the top-level directory--I'm using LLVM 12.0--but I don't know enough about the other supported compilers to include that as part of this pull request.

Thanks for the great tutorial!



Anthony